### PR TITLE
GHA upload msi to draft release

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,8 +34,9 @@ jobs:
             -Filter 'OpenNetMeter-*.msi' `
             | Select-Object -First 1
           if (-not $msi) { throw '❌ No MSI found!' }
-          # Emit the *absolute* path:
-          Write-Host "msi_path=$($msi.FullName)" >> $Env:GITHUB_OUTPUT
+
+          # Properly set the output so it can be consumed later:
+          "msi_path=$($msi.FullName)" | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
 
       - name: Create or Update Draft Release & Upload MSI
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
this uploads the built msi to a draft release. running this will simply update the draft release with the new artifact with a custom named msi